### PR TITLE
fix for bug where an error is returned if search finds only 1 result

### DIFF
--- a/lib/Rarbg/torrentapi.pm
+++ b/lib/Rarbg/torrentapi.pm
@@ -132,7 +132,7 @@ sub _make_request {
         my $tresults = decode_json( $res_json->decoded_content );
         my @res;
         if ( $tresults->{torrent_results}
-            && scalar( @{ $tresults->{torrent_results} } ) > 1 )
+            && scalar( @{ $tresults->{torrent_results} } ) )
         {
             foreach my $t ( @{ $tresults->{torrent_results} } ) {
                 my $t_obj = Rarbg::torrentapi::Res->new($t);


### PR DESCRIPTION
If search() returns 1 result, the scalar is not "> 1", so the if fails, and it returns the error object, but there IS 1 result in "$tresults->{torrent_results}".  This works for my testing.